### PR TITLE
Add a loading state

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ class App extends Component {
     this.setState({ "user": undefined });
   } 
  
+ LoadingMenu() {
+    return <div>Loading...</div>;
+ }
+ 
   NotAuthenticated() {
     return <div>You are not authenticated, please click here to authenticate.</div>;
   }
@@ -60,6 +64,7 @@ class App extends Component {
           checkAuthentication={checkAuthentication}
           userLoaded={this.userLoaded} 
           userunLoaded={this.userUnLoaded} 
+          renderLoading={this.LoadingMenu}
           renderNotAuthenticated={this.NotAuthenticated}
         >
             <div>If you see this you are authenticated.</div>

--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,9 @@ class Authenticate extends Component {
         }
 
         return (
-          <div>
-            {this.props.renderNotAuthenticated({onSignIn: this.signin})}
-          </div>
+            <div>
+                {this.props.renderNotAuthenticated({ onSignIn: this.signin })}
+            </div>
         );
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ class Authenticate extends Component {
         super(props);
         this.signin = this.signin.bind(this);
         this.onUserLoaded = this.onUserLoaded.bind(this);
-        this.state = { isAuthenticated: false };
+        this.state = { isAuthenticated: false, isLoading: false };
     }
 
     UNSAFE_componentWillMount() {
@@ -61,8 +61,10 @@ class Authenticate extends Component {
     }
 
     signin() {
+        this.setState({ isLoading: true });
         this.userManager.signinRedirect().then(function () {
             console.log('signinRedirect ok');
+
         }).catch(function (err) {
             console.log('signinRedirect error:', err);
         });
@@ -71,6 +73,14 @@ class Authenticate extends Component {
     render() {
         if (this.state.isAuthenticated) {
             return (this.props.children);
+        }
+
+        if (this.state.isLoading) {
+            return (
+                <div>
+                    {this.props.renderLoading()}
+                </div>
+            )
         }
 
         return (
@@ -85,6 +95,7 @@ Authenticate.defaultProps = {
     OidcSettings: {},
     userUnLoaded: null,
     userLoaded: null,
+    renderLoading: null,
     renderNotAuthenticated: null,
     checkAuthentication: null,
 };
@@ -124,6 +135,10 @@ Authenticate.propTypes = {
     * @property {func} userUnLoaded Raised when a user session has been terminated.
     */
     userUnLoaded: propTypes.func,
+    /**
+     * @property {func} renderLoading Renderprop used to render output when user's authentication is being processed 
+     */
+    renderLoading: propTypes.func.isRequired,
     /**
     * @property {func} renderNotAuthenticated Renderprop used to render output when user is not authenticated
     */

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ class Authenticate extends Component {
     }
 
     UNSAFE_componentWillMount() {
-
         this.userManager = new UserManager(this.props.OidcSettings);
         this.userManager.events.addUserLoaded(this.onUserLoaded);
         this.userManager.events.addUserUnloaded(this.onUserUnloaded);
@@ -29,6 +28,7 @@ class Authenticate extends Component {
             if (user !== null && user !== undefined) {
                 this.onUserLoaded(user);
             } else if (this.isSuccessfullyAuthenticated()) {
+                this.setState({ isLoading: true });
                 this.userManager.signinRedirectCallback().then(() => {
                     window.history.replaceState({}, "", "/");
                 }).catch(function (err) {
@@ -61,7 +61,6 @@ class Authenticate extends Component {
     }
 
     signin() {
-        this.setState({ isLoading: true });
         this.userManager.signinRedirect().then(function () {
             console.log('signinRedirect ok');
 
@@ -73,16 +72,13 @@ class Authenticate extends Component {
     render() {
         if (this.state.isAuthenticated) {
             return (this.props.children);
-        }
-
-        if (this.state.isLoading) {
+        } else if (this.state.isLoading) {
             return (
                 <div>
                     {this.props.renderLoading()}
                 </div>
             )
         }
-
         return (
             <div>
                 {this.props.renderNotAuthenticated({ onSignIn: this.signin })}


### PR DESCRIPTION
Right now, the authentication component doesn’t have a loading state while it validates if the user is logged in or not. So, for a brief moment, after login, the user can see the login screen again. It could cause some confusion. Also would be nice to allow the component to accept another component as property and use it while in the loading state.

- The user should not be able to see the login screen while the login is being checked
- Accept a loading component as property and use it while the loading state is true